### PR TITLE
Fix error when stdout is empty

### DIFF
--- a/audit.py
+++ b/audit.py
@@ -190,7 +190,7 @@ class CallbackModule(CallbackBase):
                 stderr = ''
 
         if 'stdout' in data.keys():
-            stdout = data['stdout'][0]
+            stdout = data['stdout']
             if stdout.startswith('WARNING') and status == 'FAILED':
                 status = 'WARNING'
                 self.stats['tasks_warning'] += 1


### PR DESCRIPTION
When a task returns empty stdout the following warning is printed:
"[WARNING]: Failure using method (v2_runner_on_ok) in callback plugin
(<ansible.plugins.callback.audit.CallbackModule object at 0x7f3150a8cbb0>):
string index out of range"

This commit removes string index which resolvs the issue.

Tested on ansible 2.9.10