### PR TITLE
Don't print stdout on successful tasks

### DIFF
--- a/audit.py
+++ b/audit.py
@@ -199,6 +199,8 @@ class CallbackModule(CallbackBase):
                 status = 'WARNING'
                 self.stats['tasks_warning'] += 1
                 self.stats['tasks_ok'] -= 1
+            else:
+                stdout = ''
         else:
             stdout = ''
 


### PR DESCRIPTION
There is no need for output of successful commands, this commit
suppresses them in report.